### PR TITLE
unescaping logic is incorrect, and the active_support tests are not actually testing what they claim

### DIFF
--- a/spec/parsing/active_support_spec.rb
+++ b/spec/parsing/active_support_spec.rb
@@ -41,16 +41,24 @@ describe "ActiveSupport test cases" do
   TESTS.each do |json, expected|
     it "should be able to parse #{json} as an IO" do
       lambda {
-        @parser.parse(StringIO.new(json)).should == expected
+        @parser.parse(StringIO.new(json))
       }.should_not raise_error(JsonMachine::ParseError)
+    end
+
+    it "should parse #{json} correctly as an IO" do
+      @parser.parse(StringIO.new(json)).should == expected
     end
   end
   
   TESTS.each do |json, expected|
     it "should be able to parse #{json} as a string" do
       lambda {
-        @parser.parse(json).should === expected
+        @parser.parse(json)
       }.should_not raise_error(JsonMachine::ParseError)
+    end
+
+    it "should parse #{json} correctly" do
+      @parser.parse(json).should == expected
     end
   end
 

--- a/spec/parsing/parsing_spec.rb
+++ b/spec/parsing/parsing_spec.rb
@@ -12,7 +12,7 @@ describe "JsonMachine::Parser" do
   
   it "should parse a string with an escaped string inside" do
     parse_str = "\"this is a string with \\\"and escaped string inside\\\"    and some padding    \""
-    compare = "this is a string with \\\"and escaped string inside\\\"    and some padding    "
+    compare = "this is a string with \"and escaped string inside\"    and some padding    "
     out = @parser.parse(parse_str)
     out.should === compare
   end


### PR DESCRIPTION
Take a look at the commits, hopefully things are self-explanatory. Not sure if you're still maintaining this, but it would be good to pull because the existing parser is largely incorrect when it comes to backslash escapes. Plus, many of the active_support tests _should_ be failing but aren't because of the way the test is written.
